### PR TITLE
CDM-431137 | Removing proxy URL from logs to avoid logging of sensitive data

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -262,7 +262,9 @@ func (c *Client) Start(ctx context.Context) error {
 	c.eg = eg
 	via := ""
 	if c.proxyURL != nil {
-		via = " via " + c.proxyURL.String()
+		// Removing c.proxyURL.String() from logs
+		// to avoid logging sensitive data in logs
+		via = " via proxy"
 	}
 	c.Infof("Connecting to %s%s\n", c.server, via)
 	//connect to chisel server


### PR DESCRIPTION
As per current code proxy details get logged in chisel logs. If customer has a auth proxy configured, then username password will get printed in logs, and this is not a good practice and will not be acceptable as well. Modifying log line to avoid logging sensitive customer data in logs

**Example:**
2024/04/25 11:58:19 logger.go:34: data-tunnel-client: Connecting to wss://proxy.rubrik.com:443 via **http://test_user:test_pass@10.0.162.30:3128**
2024/04/25 11:58:19 client: tun: proxy#localhost:10010=>v3.live.rubrik.com:8000: Listening